### PR TITLE
Rename `get_anchor`  method before removal in mkdocstrings

### DIFF
--- a/mkdocstrings_handlers/crystal/renderer.py
+++ b/mkdocstrings_handlers/crystal/renderer.py
@@ -40,8 +40,8 @@ class CrystalRenderer(base.BaseHandler):
                 root=True,
             )
 
-    def get_anchors(self, data: DocItem) -> set[str]:
-        return {data.abs_id}
+    def get_anchors(self, data: DocItem) -> tuple[str, ...]:
+        return (data.abs_id,)
 
     def update_env(self, md: Markdown, config: dict) -> None:
         super().update_env(md, config)

--- a/mkdocstrings_handlers/crystal/renderer.py
+++ b/mkdocstrings_handlers/crystal/renderer.py
@@ -40,8 +40,8 @@ class CrystalRenderer(base.BaseHandler):
                 root=True,
             )
 
-    def get_anchor(self, data: DocItem) -> str:
-        return data.abs_id
+    def get_anchors(self, data: DocItem) -> set[str]:
+        return {data.abs_id}
 
     def update_env(self, md: Markdown, config: dict) -> None:
         super().update_env(md, config)


### PR DESCRIPTION
There wasn't any deprecation warning, my bad.

It's also possible to return a tuple instead of a set.