### PR TITLE
Update rendering of docs, fix some docstrings

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,4 +1,5 @@
-.highlight .gp { /* Generic.Prompt */
+.highlight .gp {
+  /* Generic.Prompt */
   user-select: none;
 }
 
@@ -7,9 +8,32 @@
   font-size: inherit;
 }
 
-/* https://mkdocstrings.github.io/handlers/python/#recommended-style-material */
+/* https://mkdocstrings.github.io/python/usage/customization/#material */
 
+/* Indentation. */
 div.doc-contents:not(.first) {
-  padding-left: 15px;
-  border-left: 4px solid rgba(230, 230, 230);
+  padding-left: 25px;
+  border-left: .05rem solid var(--md-typeset-table-color);
+}
+
+/* Mark external links as such. */
+a.external::after,
+a.autorefs-external::after {
+  /* https://primer.style/octicons/arrow-up-right-24 */
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.25 15.5a.75.75 0 00.75-.75v-9a.75.75 0 00-.75-.75h-9a.75.75 0 000 1.5h7.19L6.22 16.72a.75.75 0 101.06 1.06L17.5 7.56v7.19c0 .414.336.75.75.75z"></path></svg>');
+  -webkit-mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.25 15.5a.75.75 0 00.75-.75v-9a.75.75 0 00-.75-.75h-9a.75.75 0 000 1.5h7.19L6.22 16.72a.75.75 0 101.06 1.06L17.5 7.56v7.19c0 .414.336.75.75.75z"></path></svg>');
+  content: ' ';
+
+  display: inline-block;
+  vertical-align: middle;
+  position: relative;
+
+  height: 1em;
+  width: 1em;
+  background-color: var(--md-typeset-a-color);
+}
+
+a.external:hover::after,
+a.autorefs-external:hover::after {
+  background-color: var(--md-accent-fg-color);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,12 +27,19 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          import:
+          - https://mkdocstrings.github.io/objects.inv
           options:
             filters: ["!^_[^_]", "!__new__"]
             show_signature_annotations: true
             show_source: false
             show_root_heading: true
             show_root_full_path: false
+            merge_init_into_class: true
+            separate_signature: true
+            signature_crossrefs: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
 
 markdown_extensions:
   - pymdownx.highlight

--- a/mkdocstrings_handlers/crystal/items.py
+++ b/mkdocstrings_handlers/crystal/items.py
@@ -84,8 +84,10 @@ class DocItem(metaclass=abc.ABCMeta):
 
         Params:
             identifier: The item to search for.
+
         Returns:
             An object that's a subclass of DocItem.
+
         Raises:
             CollectionError: When an item by that identifier couldn't be found.
         """
@@ -465,7 +467,8 @@ class DocMapping(Generic[D]):
         """`mapping["identifier"]` to get the item by this identifier (see [DocItem.rel_id][mkdocstrings_handlers.crystal.items.DocItem.rel_id]).
 
         Returns:
-            A [DocItem][mkdocstrings_handlers.crystal.items.DocItem]
+            A [DocItem][mkdocstrings_handlers.crystal.items.DocItem].
+
         Raises:
             KeyError: if the item is missing.
         """


### PR DESCRIPTION
![crystal](https://github.com/mkdocstrings/crystal/assets/3999221/cb36d82d-8030-446f-92e0-183f42e88f99)

It uses some mkdocstrings-python insiders features :grinning: (`signature_crossrefs`, `show_symbol_type_heading` and `show_symbol_type_toc`).

Let me know what you think, just had some fun trying latest mkdocstrings and mkdocstrings-python on your handler docs :smile: 

Also I've identified the problematic docstring sections with this:

```console
% griffe dump -Ldebug -o/dev/null -fdgoogle mkdocstrings_handlers.crystal 2>&1 | grep reasons
DEBUG      mkdocstrings_handlers/crystal/items.py:87: Possible section skipped, reasons: Missing blank line above section
DEBUG      mkdocstrings_handlers/crystal/items.py:89: Possible section skipped, reasons: Missing blank line above section
DEBUG      mkdocstrings_handlers/crystal/items.py:469: Possible section skipped, reasons: Missing blank line above section
```

(latest Griffe is a bit more strict about section syntax, to avoid false-positives)